### PR TITLE
品物詳細ページの作成

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,8 @@ class User < ApplicationRecord
 
   validates :email, uniqueness: true, presence: true
   validates :name, presence: true, length: { maximum: 255 }
+
+  def own?(object)
+    id == object.user_id
+  end
 end

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,8 +1,10 @@
-<div>
-  <ul class="pb-5">
-    <li class="pb-3 text-xl font-bold cursor-pointer"><%= t('items.index.name') %><%= link_to item.name, "#" %></li>
+<div class="mb-5">
+  <ul class="p-5 border-4 border-[#5b4744] border-dashed rounded-3xl shadow-xl bg-[#eee5bc]">
+    <li class="pb-1 text-xl font-bold"><%= t('items.index.name') %><%= link_to item.name, item_path(item) %></li>
+    <li class="pb-1 text-xl font-bold">by：<%= link_to item.user.name , "#" %></li>
     <li><%= image_tag item.item_image.url, size: '300x300', class:"pb-3" %></li>
-    <%# <li><%= item.episode_content %></li>
-    <li class="text-lg"><%= item.reason_status_i18n %><%= t('items.index.reason') %><%= item.reason_content %></li>
+    <li><p class="text-xl font-bold"><%= item.reason_status_i18n %><%= t('items.index.reason') %></p>
+        <p class="text-lg"><%= item.reason_content %></p>
+    </li>
   </ul>
 </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,30 @@
+<div class="bg-[#f5eace]">
+<%= render 'shared/header' %>
+  <div class="container mx-auto">
+    <h1 class="secondary-title"><%= t('.title') %></h1>
+  
+    <div class="-mx-2 md:flex">
+      <div class="px-10 pb-3 mb-8 text-xl font-bold md:w-1/2">
+        <%= t('items.show.name') %><%= @item.name %><br>
+        <p class="mt-2">by：<%= @item.user.name %></p>
+        <%= image_tag @item.item_image.url, size:'400x400', class:"mt-4" %>
+      </div>
+      <div class="px-10 pb-5 md:w-1/2">
+        <div class="mb-5">
+          <p class="text-xl font-bold "><%= t('items.show.episode_content') %></p>
+          <%= @item.episode_content %>
+        </div>
+        <div class="mb-5">
+          <p class="text-xl font-bold"><%= @item.reason_status_i18n %><%= t('items.show.reason') %></p>
+          <%= @item.reason_content %>
+        </div>
+        <% if current_user.own?(@item) %>
+          <div class="flex justify-end space-x-5">
+            <%= button_to t('items.show.edit'), "#" , class: "px-5 py-2 text-xl font-bold text-white transition-all duration-300 bg-green-500 rounded cursor-pointer hover:bg-green-600"%>
+            <%= button_to t('items.show.destroy'), "#" , class: "px-5 py-2 text-xl font-bold text-white transition-all duration-300 bg-red-500 rounded cursor-pointer hover:bg-red-600"%>
+          </div>
+        <% end %>
+      </div> 
+    </div>
+  </div>  
+</div>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -40,3 +40,11 @@ ja:
       item_image: '写真'
       tag: 'タグ'
       genre: 'ジャンル'
+    show:
+      title: '品物詳細'
+      name: '品物名：'
+      episode_content: '思い出エピソード'
+      reason: '理由'
+      tag: 'タグ：'
+      edit: '編集'
+      destroy: '削除'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,5 +14,5 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
 
   resources :users, only: %i[new create]
-  resources :items, only: %i[index new create]
+  resources :items, only: %i[index new create show]
 end


### PR DESCRIPTION
## 概要

品物詳細ページの作成を行いました。
また、ログインしているユーザーの投稿にのみ「編集」「削除」ボタンが表示されるように実装しました。

## 確認方法

1. 品物一覧ページ（/items)の品物名をクリックしてください
2. 品物詳細ページに遷移できることを確認してください
3. ログインしているユーザーの投稿にのみ「編集」「削除」ボタンが表示されることを確認してください

## 影響範囲

品物一覧ページにて、各品物名をクリックすると詳細画面に遷移します。

## チェックリスト

- [x] Lint のチェックをパスした
