### PR TITLE
画像加工と大容量の写真の投稿制限の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,3 +92,5 @@ gem 'enum_help'
 gem 'pry-byebug'
 
 gem 'kaminari'
+
+gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -371,6 +371,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kaminari
+  mini_magick
   pg (~> 1.1)
   pry-byebug
   puma (>= 5.0)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -39,8 +39,8 @@ class ItemsController < ApplicationController
       @item.save_tags(tag_list)
       redirect_to items_path, info: t('defaults.message.updated', item: Item.model_name.human)
     else
-      flash.now[:error] = t('defaults.message.updated', item: Item.model_name.human)
-      render :edit
+      flash.now[:error] = t('defaults.message.not_updated', item: Item.model_name.human)
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/mypage/profiles_controller.rb
+++ b/app/controllers/mypage/profiles_controller.rb
@@ -12,7 +12,7 @@ class Mypage::ProfilesController < Mypage::BaseController
       redirect_to mypage_profile_path, info: t('defaults.message.updated', item: User.model_name.human)
     else
       flash.now[:error] = t('defaults.message.not_updated', item: User.model_name.human)
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/uploaders/icon_uploader.rb
+++ b/app/uploaders/icon_uploader.rb
@@ -1,7 +1,11 @@
 class IconUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
-  # include CarrierWave::MiniMagick
+  include CarrierWave::MiniMagick
+
+  def size_range
+    1..5.megabytes
+  end
 
   # Choose what kind of storage to use for this uploader:
   storage :file
@@ -25,7 +29,7 @@ class IconUploader < CarrierWave::Uploader::Base
   # end
 
   # Process files as they are uploaded:
-  # process scale: [200, 300]
+  process resize_to_fit: [200, 200]
   #
   # def scale(width, height)
   #   # do something

--- a/app/uploaders/item_image_uploader.rb
+++ b/app/uploaders/item_image_uploader.rb
@@ -1,7 +1,11 @@
 class ItemImageUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
-  # include CarrierWave::MiniMagick
+  include CarrierWave::MiniMagick
+
+  def size_range
+    1..5.megabytes
+  end
 
   # Choose what kind of storage to use for this uploader:
   storage :file
@@ -25,7 +29,7 @@ class ItemImageUploader < CarrierWave::Uploader::Base
   # end
 
   # Process files as they are uploaded:
-  # process scale: [200, 300]
+  process resize_to_fit: [400, 400]
   #
   # def scale(width, height)
   #   # do something

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -31,6 +31,7 @@ ja:
       deleted: '%{item}を削除しました'
       delete_confirm: '削除しますか？'
       not_authorized: '権限がありません'
+      
   users:
     new:
       title: 'アカウント登録'


### PR DESCRIPTION
## 概要

画像加工と大容量の写真の投稿制限の追加を行いました。

## 確認方法

1. 投稿フォーム、品物編集ページ、アカウント変更ページで大容量の写真を投稿してみてください
2. エラーメッセージが出ることを確認してください

## 影響範囲

投稿フォーム、品物編集ページ、アカウント変更ページの範囲です。

## チェックリスト

- [x] Lint のチェックをパスした
