### PR TITLE
チャットルームでのバグ修正、その他

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 .secondary-title {
-  @apply md:text-3xl text-2xl font-bold py-2 my-3;
+  @apply md:text-3xl text-2xl font-bold py-2 my-3 px-3;
 }
 
 .secondary-title::after {

--- a/app/controllers/chat_rooms_controller.rb
+++ b/app/controllers/chat_rooms_controller.rb
@@ -13,20 +13,8 @@ class ChatRoomsController < ApplicationController
     if Entry.where(user_id: current_user.id, chat_room_id: @chat_room.id).present?
       @messages = @chat_room.messages
       @entries = @chat_room.entries
-      
     else
       redirect_back(fallback_location: root_path)
     end
-  end
-
-  def create
-    current_user.follow(params[:user_id])
-    ActiveRecord::Base.transaction do
-      @chat_room = ChatRoom.create(name: "DM")
-      Entry.create(user_id: current_user.id, chat_room_id: chat_room.id)
-      Entry.create(user_id: params[:user_id], chat_room_id: chat_room.id)
-    end
-    User.find(params[:user_id]).create_natification_follow(current_user)
-    redirect_to request.referer
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -114,6 +114,10 @@ class ItemsController < ApplicationController
     respond_to(&:js)
   end
 
+  def private_items
+    @private_items = current_user.items.unpublished.order(created_at: :desc).page(params[:page]).per(6)
+  end
+
   private
 
   def set_item

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -3,6 +3,11 @@ class RelationshipsController < ApplicationController
 
   def create
     current_user.follow(params[:user_id])
+    ActiveRecord::Base.transaction do
+      @chat_room = ChatRoom.create(name: "DM")
+      Entry.create(user_id: current_user.id, chat_room_id: @chat_room.id)
+      Entry.create(user_id: params[:user_id], chat_room_id: @chat_room.id)
+    end
     User.find(params[:user_id]).create_notification_follow(current_user)
     redirect_to request.referer
   end

--- a/app/javascript/channels/room_channel.js
+++ b/app/javascript/channels/room_channel.js
@@ -11,19 +11,15 @@ document.addEventListener('turbo:load', function() {
     {channel: "RoomChannel", chat_rooms: chatRoomId}, {
     connected() {
       // Called when the subscription is ready for use on the server
-      console.log('WebSocketが接続されました');
     },
 
     disconnected() {
       // Called when the subscription has been terminated by the server
-      console.log('WebSocketが切断されました');
     },
 
     received: function(data) {
       // Called when there's incoming data on the websocket for this channel
-      console.log('データが受信されました:', data);
       const messages = document.getElementById('messages');
-      console.log(messages);
       messages.insertAdjacentHTML('beforeend', data['message']);
     },
 
@@ -41,8 +37,13 @@ document.addEventListener('turbo:load', function() {
       formInput.value = '';
       event.preventDefault();
     });
-
-  } else {
-    console.log("このページではAction Cableが接続されていません。");
+    
+    formInput.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        submitButton.dispatchEvent(new PointerEvent("click"));
+        e.preventDefault();
+      }  
+      return false;
+    });
   }
 });

--- a/app/uploaders/icon_uploader.rb
+++ b/app/uploaders/icon_uploader.rb
@@ -32,7 +32,7 @@ class IconUploader < CarrierWave::Uploader::Base
   # end
 
   # Process files as they are uploaded:
-  process resize_to_fit: [200, 200]
+  process resize_and_pad: [200, 200, "#ffffff", "Center"]
   #
   # def scale(width, height)
   #   # do something

--- a/app/views/chat_rooms/_message.html.erb
+++ b/app/views/chat_rooms/_message.html.erb
@@ -1,4 +1,4 @@
-<div class="mx-10 mb-5 md:mx-auto" style="text-align: right;">
+<div class="mx-10 mb-5 md:mx-auto" id="output" style="text-align: right;">
   <p class="message_<%= message.id %>">
 	<span><%= message.user.name %></span><br>
 		<span class="messege border-2 border-solid bg-[#e9d478] border-black rounded-xl px-5"><%= message.message %></span><br>

--- a/app/views/chat_rooms/entrance.html.erb
+++ b/app/views/chat_rooms/entrance.html.erb
@@ -1,17 +1,23 @@
-<div class="bg-[#f5eace]">
+<%= content_for(:title, t('.title')) %>
+<div class="bg-[#f5eace] grow">
 <%= render 'shared/header' %>
   <div>
     <div class="container mx-auto">
       <h1 class="secondary-title"><%= t('.title') %></h1>
-      <div class="grid grid-cols-1 gap-10 pb-6 lg:grid-cols-3 md:grid-cols-2 auto-rows-auto place-content-center place-items-center">
+      <ul class="grid grid-cols-1 gap-4 pb-6 lg:grid-cols-3 md:grid-cols-2 auto-rows-auto place-content-center place-items-center">
           <% if logged_in? %>
-            <% @followers.each do |follower| %>
-              <%= link_to chat_room_path(follower.followed.id) do %>
-                <%= "#{follower.followed.name}" %>
+            <% if @followers.present? %>
+              <% @followers.each do |follower| %>
+                <%= link_to chat_room_path(follower.followed.id) , class:"border-4 border-[#5b4744] border-dashed rounded-3xl shadow-xl bg-[#eee5bc] flex items-center w-[325px] h-[200px] p-5 mb-8" do %>
+                  <li><%= image_tag follower.followed.icon.url, size: '150x150', class:"rounded-full mr-5" %></li>
+                  <li class="text-xl font-bold"><%= "#{follower.followed.name}" %></li>
+                <% end %>
               <% end %>
+            <% else %>
+              <p><%= t('.no_result') %><br>フォローして、チャットましょう！</p>
             <% end %>
           <% end %>
-      </div>
+      </ul>
     </div>
   </div>
 </div>

--- a/app/views/chat_rooms/show.html.erb
+++ b/app/views/chat_rooms/show.html.erb
@@ -3,7 +3,8 @@
     import consumer from 'channels/action_cable';
   </script>
 <% end %>
-<div class="bg-[#f5eace]">
+<%= content_for(:title, t('.title')) %>
+<div class="bg-[#f5eace] grow">
 <%= render 'shared/header' %>
   <div>
     <div class="container md:mx-auto">
@@ -22,14 +23,13 @@
           <% end %>
       <% end %>
       
-      <div class="lg:ml-48" id='messages'>
+      <div class="lg:mr-24 md:mx-12 lg:ml-48" id='messages'>
         <div id="chats" data-id ="<%= @chat_room.id %>">
           <%= render partial: 'chat_rooms/message',collection: @messages, as: :message %>
         </div>
       </div>
-      <form class="mx-10 md:mx-auto" id="target">
-        <label class="font-bold talk-form">Say something:</label><br>
-        <input type = "text" class="mb-10 w-52 sm:w-9/12 md:w-10/12 lg:w-11/12" id ="talk-form" placeholder="メッセージ" data-behavior = "chat_room_speaker" data-user = "<%= current_user.id %>" data-room = "<%= @chat_room.id %>">
+      <form class="mx-10 text-center md:mx-auto lg:ml-48 lg:text-start" id="target">
+        <input type = "text" class="mb-10 w-52 sm:w-9/12 md:w-10/12" id ="talk-form" placeholder="メッセージ" data-behavior = "chat_room_speaker" data-user = "<%= current_user.id %>" data-room = "<%= @chat_room.id %>">
         <button type="button" id="send-button" class="px-5 py-2 text-xl font-bold text-white transition-all duration-300 bg-green-500 rounded cursor-pointer hover:bg-green-600 text-end">送信</button>
       </form>
     </div>

--- a/app/views/contacts/confirm.html.erb
+++ b/app/views/contacts/confirm.html.erb
@@ -1,5 +1,5 @@
 <%= content_for(:title, t('.title')) %>
-<div class="bg-[#f5eace]">
+<div class="bg-[#f5eace] grow">
 <% if logged_in? %>
   <%= render 'shared/header' %>
 <% else %>

--- a/app/views/contacts/done.html.erb
+++ b/app/views/contacts/done.html.erb
@@ -1,5 +1,5 @@
 <%= content_for(:title, t('.title')) %>
-<div class="bg-[#f5eace]">
+<div class="bg-[#f5eace] grow">
 <% if logged_in? %>
   <%= render 'shared/header' %>
 <% else %>

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -1,5 +1,5 @@
 <%= content_for(:title, t('.title')) %>
-<div class="bg-[#f5eace]">
+<div class="bg-[#f5eace] grow">
 <% if logged_in? %>
   <%= render 'shared/header' %>
 <% else %>
@@ -12,6 +12,7 @@
         <%= form_with model: @contact, local: true, url: confirm_contacts_path, data: { turbo: false } do |f| %>
           <div class="form-group">
             <%= f.label :name, Contact.human_attribute_name(:name), class:"font-bold text-xl" %><br>
+            <% binding.pry %>
             <%= f.text_field :name, class: "form-control rounded focus:ring-gray-500 focus:border-gray-500 mb-5 w-4/5", placeholder: 'eri' %>
           </div>
           <div class="form-group">

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -50,7 +50,7 @@
           <%= f.label :status, t('enums.item.status.unpublished') %>
         </div>
           
-        <div class="mt-5 text-center md:text-end">
+        <div class="mt-8 text-center md:text-end">
           <%= f.submit t('defaults.submission'), class:"bg-green-500 hover:bg-green-600 transition-all duration-300 text-white rounded py-3 px-12 font-bold text-xl cursor-pointer " %>
         </div>
       </div>

--- a/app/views/items/all_items.html.erb
+++ b/app/views/items/all_items.html.erb
@@ -1,4 +1,5 @@
-<div class="bg-[#f5eace]">
+<%= content_for(:title, t('.title')) %>
+<div class="bg-[#f5eace] grow">
 <%= render 'shared/header' %>
   <div>
     <div class="container mx-auto">
@@ -7,7 +8,7 @@
         <% if @all_items.present? %>
           <%= render @all_items %>
         <% else %>
-          <p><%= t('.no_result') %></p>
+          <p><%= t('.no_result') %><br>思い出の品物を投稿しましょう！</p>
         <% end %>
       </div>
       <%= paginate @all_items %>

--- a/app/views/items/private_items.html.erb
+++ b/app/views/items/private_items.html.erb
@@ -1,0 +1,17 @@
+<% content_for(:title, t('.title')) %>
+<div class="bg-[#f5eace] h-screen">
+<%= render 'shared/header' %>
+  <div>
+    <div class="container mx-auto">
+      <h1 class="secondary-title"><%= t('.title') %></h1>
+      <div class="grid grid-cols-1 gap-10 lg:grid-cols-3 md:grid-cols-2 auto-rows-auto place-content-center place-items-center">
+        <% if @private_items.present? %>
+          <%= render @private_items %>
+        <% else %>
+          <p><%= t('.no_result') %></p>
+        <% end %>
+      </div>
+      <%= paginate @private_items %>
+    </div>
+  </div>
+</div>

--- a/app/views/items/search.html.erb
+++ b/app/views/items/search.html.erb
@@ -1,4 +1,5 @@
-<div class="bg-[#f5eace]">
+<%= content_for(:title, t('.title')) %>
+<div class="bg-[#f5eace] grow">
 <% if logged_in? %>
   <%= render 'shared/header' %>
 <% else %>
@@ -11,7 +12,8 @@
         <% if  @search_results.present? %>
           <%= render @search_results %>
         <% else %>
-          <p><%= t('.no_result') %></p>
+          <p><%= t('.no_result') %><br>
+          <%= link_to "他の人の投稿", items_path, class: "underline pointer text-xl font-bold"%>を見てみましょう！</p>
         <% end %>
       </div>
     </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,9 +25,9 @@
           <p class="mt-2">by：<%= @item.user.name %></p>
         <% end %>
         
-        <%= image_tag @item.item_image.url, size:'400x400', class:"mt-4" %>
+        <%= image_tag @item.item_image.url, size:'400x400', class:"mt-4 sm:mx-auto" %>
       </div>
-      <div class="px-10 pb-5 md:w-1/2">
+      <div class="px-10 pb-11 md:w-1/2">
         <div>
           <% if logged_in? %>
             <% if @item.favorited?(current_user) %>

--- a/app/views/items/stay_items.html.erb
+++ b/app/views/items/stay_items.html.erb
@@ -1,4 +1,5 @@
-<div class="bg-[#f5eace]">
+<%= content_for(:title, t('.title')) %>
+<div class="bg-[#f5eace] grow">
 <%= render 'shared/header' %>
   <div>
     <div class="container mx-auto">

--- a/app/views/items/trashed_items.html.erb
+++ b/app/views/items/trashed_items.html.erb
@@ -1,4 +1,5 @@
-<div class="bg-[#f5eace]">
+<%= content_for(:title, t('.title')) %>
+<div class="bg-[#f5eace] grow">
 <%= render 'shared/header' %>
   <div>
     <div class="container mx-auto">

--- a/app/views/items/worry_items.html.erb
+++ b/app/views/items/worry_items.html.erb
@@ -1,4 +1,5 @@
-<div class="bg-[#f5eace]">
+<%= content_for(:title, t('.title')) %>
+<div class="bg-[#f5eace] grow">
 <%= render 'shared/header' %>
   <div>
     <div class="container mx-auto">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
     </script>
   </head>
 
-  <body>
+  <body class="flex flex-col min-h-screen">
     <%= render 'shared/flash_messages' %>
     <%= yield %>
     <%= render 'shared/footer' %>

--- a/app/views/mypage/layouts/application.html.erb
+++ b/app/views/mypage/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>DANSYARI</title>
+    <title><%= page_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -15,8 +15,6 @@
   <body>
     <%= render 'shared/flash_messages' %>
     <%= yield %>
-    <% if logged_in? %>
-      <%= render 'shared/footer' %>
-    <% end %>
+    <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/mypage/profile_shows/show.html.erb
+++ b/app/views/mypage/profile_shows/show.html.erb
@@ -24,7 +24,7 @@
             <% end %>
           </div>
           <div>
-            <p class="pt-3 mb-3 text-3xl sm:pt-0"><%= @user.name %></p>
+            <p class="mt-3 mb-3 text-3xl sm:mt-0"><%= @user.name %></p>
             <%= link_to follows_user_path(@user) do %>
               <p class="mb-1 text-xl"><%= t('mypage.profiles.show.follow') %><%= @user.followers.count %>人</p>
             <% end %>
@@ -34,7 +34,7 @@
           </div>
           
         </div>
-        <div class="flex justify-center mt-20 mb-20 md:space-x-12">
+        <div class="flex justify-center mt-20 mb-10 space-x-12">
           <div>
             <%= link_to trashed_item_path do %>
               <p class="mb-5 text-2xl text-center md:mb-2"><%= t('mypage.profiles.show.trash_items') %></p>

--- a/app/views/mypage/profiles/edit.html.erb
+++ b/app/views/mypage/profiles/edit.html.erb
@@ -1,3 +1,4 @@
+<%= content_for(:title, t('.title')) %>
 <div class="bg-[#f5eace]">
   <%= render 'shared/header' %>
   <div class="container mx-auto">

--- a/app/views/mypage/profiles/show.html.erb
+++ b/app/views/mypage/profiles/show.html.erb
@@ -9,6 +9,9 @@
         <p class="third-title">サイドバー</p>
         <ul>
           <li class="mb-3"><%= link_to t('mypage.profiles.show.items_list'), all_items_path %></li>
+          
+          <li class="mb-3"><%= link_to t('mypage.profiles.show.private_item_list'), private_item_list_items_path %></li>
+          
           <li class="mb-3"><%= link_to t('mypage.profiles.show.good'), favorites_user_path(current_user) %></li>
           <li class="mb-3"><%= link_to t('mypage.profiles.show.edit_account'), edit_mypage_profile_path %></li>
         </ul>
@@ -24,7 +27,7 @@
             <% end %>
           </div>
           <div>
-            <p class="pt-3 mb-3 text-3xl sm:pt-0"><%= current_user.name %></p>
+            <p class="mt-3 mb-3 text-3xl sm:mt-0"><%= current_user.name %></p>
             <%= link_to follows_user_path(@user) do %>
               <p class="mb-1 text-xl"><%= t('mypage.profiles.show.follow') %><%= @user.followers.count %>人</p>
             <% end %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,8 +1,10 @@
-<%= render 'shared/header' %>
-<% notifications = @notifications.where.not(visitor_id: current_user.id) %>
-<% if notifications.exists? %>
-  <%= render partial: 'notification', collection: @notifications, as: :notification %>
-  <%= paginate notifications %>
-<% else %>
-  <%= t('notification.index.no_result') %>
-<% end %>
+<div class="grow">
+  <%= render 'shared/header' %>
+  <% notifications = @notifications.where.not(visitor_id: current_user.id) %>
+  <% if notifications.exists? %>
+    <%= render partial: 'notification', collection: @notifications, as: :notification %>
+    <%= paginate notifications %>
+  <% else %>
+    <%= t('notification.index.no_result') %>
+  <% end %>
+</div>

--- a/app/views/relationships/_follow_user.html.erb
+++ b/app/views/relationships/_follow_user.html.erb
@@ -1,5 +1,10 @@
 <div class="mb-5">
-  <ul class="p-5 border-4 border-[#5b4744] border-dashed rounded-3xl shadow-xl bg-[#eee5bc]">
+  <ul class="p-5 border-4 border-[#5b4744] border-dashed rounded-3xl shadow-xl bg-[#eee5bc] flex items-center w-[325px] h-[200px]">
+    <li>
+      <%= link_to (current_user == user ? mypage_profile_path(current_user) : mypage_profile_show_path(user)) do %>
+        <%= image_tag user.icon.url, size: '150x150', class:"rounded-full mr-5" %>
+      <% end %>
+    </li>
     <li class="pb-1 text-xl font-bold">
       <%= link_to (current_user == user ? mypage_profile_path(current_user) : mypage_profile_show_path(user)) do %>
         <%= user.name %>

--- a/app/views/relationships/followers.html.erb
+++ b/app/views/relationships/followers.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-[#f5eace]">
+<div class="bg-[#f5eace] grow">
 <%= render 'shared/header' %>
   <div>
     <div class="container mx-auto">

--- a/app/views/relationships/followings.html.erb
+++ b/app/views/relationships/followings.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-[#f5eace]">
+<div class="bg-[#f5eace] grow">
 <%= render 'shared/header' %>
   <div>
     <div class="container mx-auto">
@@ -7,7 +7,7 @@
         <% if @users.present? %>
           <%= render partial: 'follow_user', collection: @users, as: :user %>
         <% else %>
-          <p><%= t('.no_result') %></p>
+          <p><%= t('.no_result') %><br>フォローしてみましょう！</p>
         <% end %>
       </div>
     </div>

--- a/app/views/users/favorites.html.erb
+++ b/app/views/users/favorites.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-<div class="bg-[#f5eace]">
+<div class="bg-[#f5eace] grow">
 <%= render 'shared/header' %>
   <div>
     <div class="container mx-auto">
@@ -8,7 +8,7 @@
         <% if @favorite_items.present? %>
           <%= render partial: 'favorite', collection: @favorite_items, as: :item %>
         <% else %>
-          <p><%= t('.no_result') %></p>
+          <p><%= t('.no_result') %><br><%= link_to "他の人の投稿", items_path, class: "underline pointer text-xl font-bold"%>を見て、いいねしてみましょう！</p>
         <% end %>
       </div>
       <%= paginate @favorite_items %>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -96,6 +96,10 @@ ja:
       no_result: '悩み中の品物はありません'
     all_items:
       title: '思い出の品物一覧'
+      no_result: '思い出の品物がありません'
+    private_items:
+      title: '非公開の思い出の品物一覧'
+      no_result: '非公開の思い出の品物はありません'
     search_tag:
       title: '検索結果（タグ）'
       no_result: 'タグはありません'
@@ -115,6 +119,7 @@ ja:
         good: 'いいね一覧'
         chat_room: 'チャットルーム'
         items_list: '思い出の品物一覧'
+        private_item_list: '非公開の思い出の品物一覧'
         follow: 'フォロー中：'
         follower: 'フォロワー：'
         edit_account: 'アカウント変更'
@@ -136,6 +141,7 @@ ja:
   chat_rooms:
     entrance:
       title: 'チャットできるユーザ一覧（フォローしているユーザー）'
+      no_result: 'チャットできるユーザ一がいません'
     show:
       title: 'チャットルーム'
   contacts:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
       get 'search', to: 'items#search', as: :search
     end
     get 'autocomplete', on: :collection, to: 'items#autocomplete'
+    get 'private_item_list', on: :collection, to: 'items#private_items'
   end
 
   namespace :mypage do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,7 +28,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_25_023603) do
     t.datetime "updated_at", null: false
     t.string "commentable_type", default: " ", null: false
     t.bigint "commentable_id", default: 0, null: false
-    t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable"
+    t.index %w[commentable_type commentable_id], name: "index_comments_on_commentable"
     t.index ["item_id"], name: "index_comments_on_item_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
@@ -71,7 +71,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_25_023603) do
     t.bigint "tag_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["item_id", "tag_id"], name: "index_item_tags_on_item_id_and_tag_id", unique: true
+    t.index %w[item_id tag_id], name: "index_item_tags_on_item_id_and_tag_id", unique: true
     t.index ["item_id"], name: "index_item_tags_on_item_id"
     t.index ["tag_id"], name: "index_item_tags_on_tag_id"
   end


### PR DESCRIPTION
## 概要

チャットルームでのバグ修正のほか、以下の点を修正、追加しました。
- ブラウザのコンソール表示の削除
- 投稿を非表示にした場合、非公開の投稿がわかるように、マイページのサイドバーにリンク追加
- 各画面下の余白の削除
- 検索結果がなかった場合の文言の追加と品物一覧ページのリンクを付与
- フォロー・フォロワー画面、チャットルーム画面にユーザーのアイコン挿入

## チェックリスト

- [x] Lint のチェックをパスした
